### PR TITLE
Adds extractMeta support so that Parse's count parameter is returned as metadata

### DIFF
--- a/lib/ember-parse-serializer.js
+++ b/lib/ember-parse-serializer.js
@@ -18,6 +18,17 @@ var ParseSerializer = DS.ParseSerializer = DS.RESTSerializer.extend({
   },
 
   /**
+   * Extracts count from the payload so that you can get the total number
+   * of records in Parse if you're using skip and limit.
+   */
+  extractMeta: function(store, type, payload) {
+    if (payload && payload.count) {
+      store.metaForType(type, {count: payload.count});
+      delete payload.count;
+    }
+  },
+  
+  /**
    * Special handling for the Date objects inside the properties of
    * Parse responses.
    */


### PR DESCRIPTION
If you pass `count=1` to Parse's REST API, it will include a total count of records in the response but it's outside the `results` part of the payload so you can't access it using the current ember-parse-adapter. This pull request grabs that count and adds it to the model's metadata.

The following route code is an example where you might be paginating results:

``` javascript
model: function(params) {
  var limit = 10;
  var skip = params.page * limit;

  return this.store.find("my_parse_model", {limit: limit, skip: skip, count: 1});
}
```

To get the total count from the meta, you would simply add a controller property like this:

``` javascript
totalNumberOfRecords: function() {
  return this.store.metadataFor("my_parse_model").count;
}.property("totalNumberOfRecords")
```
