### PR TITLE
ember-data's default rest adapter uses dash

### DIFF
--- a/lib/ember-parse-adapter.js
+++ b/lib/ember-parse-adapter.js
@@ -185,7 +185,7 @@ Ember.onLoad('Ember.Application', function(Application) {
   Application.initializer({
     name: "parseAdapter",
     initialize: function(container, application) {
-      application.register('adapter:_parse', DS.ParseAdapter);
+      application.register('adapter:-parse', DS.ParseAdapter);
     }
   });
 });


### PR DESCRIPTION
I noticed that in ember-data they've switched from underscore to dash, figured I'd spread the consistency.
