### PR TITLE
Add wrapping of where clause to adapter findQuery

### DIFF
--- a/lib/ember-parse-adapter/adapter.js
+++ b/lib/ember-parse-adapter/adapter.js
@@ -137,6 +137,36 @@ EmberParseAdapter.Adapter = DS.RESTAdapter.extend({
     return this.ajax(this.buildURL(relatedInfo.type.typeKey), "GET", { data: query });
   },
 
+  /**
+   * Implementation of findQuery that automatically places the query in a where clause for brevity
+   *
+   * @example
+   *     this.store.find('comment', {
+   *         post: {
+   *             "__type":  "Pointer",
+   *             "className": "Post",
+   *             "objectId": post.get('id')
+   *         }
+   *     });
+   */
+  findQuery: function (store, type, query) {
+    var whereQuery = query;
+
+    if (!whereQuery.where) {
+      // Wrap in a where clause
+      whereQuery = {
+        where: whereQuery
+      };
+    }
+
+    if (Ember.typeOf(whereQuery.where) !== 'string') {
+      whereQuery.where = JSON.stringify(whereQuery.where);
+    }
+
+    // Pass to _super()
+    return this._super(store, type, whereQuery);
+  },
+
   sessionToken: Ember.computed('headers.X-Parse-Session-Token', function(key, value){
     if (arguments.length < 2) {
       return this.get('headers.X-Parse-Session-Token');

--- a/test/ember-parse-adapter/adapter-test.js
+++ b/test/ember-parse-adapter/adapter-test.js
@@ -150,12 +150,31 @@ pending("findMany via a hasMany relationship", function(){
   });
 });
 
-test("Find Query", function(){
-  posts = store.find('post', {where: JSON.stringify({title: 'First Post'})});
+test("Find Query without where", function(){
+  posts = store.find('post', {title: 'First Post'});
   equal(get(posts, 'length'), 0, "there are no posts yet as the query has not returned.");
   expect(ajaxUrl, "/1/classes/Post", "requests the post class");
   equal(ajaxType, "GET");
-  deepEqual(ajaxHash.data, {where: JSON.stringify({title: 'First Post'})}, "where clause is passed as data");
+  deepEqual(ajaxHash.data, {where: JSON.stringify({title: 'First Post'}) }, "where clause is passed as stringified data");
+  ajaxHash.success({
+    results: [
+      { objectId: 'bad1', title: 'First Post'},
+      { objectId: 'bad2', title: 'First Post'}
+    ]
+  });
+
+  equal(get(posts, 'length'), 2, "there are 2 posts loaded");
+  posts.forEach(function(post){
+    equal(get(post, 'isLoaded'), true, "the post is being loaded");
+  });
+});
+
+test("Find Query with where", function(){
+  posts = store.find('post', {where: {title: 'First Post'}});
+  equal(get(posts, 'length'), 0, "there are no posts yet as the query has not returned.");
+  expect(ajaxUrl, "/1/classes/Post", "requests the post class");
+  equal(ajaxType, "GET");
+  deepEqual(ajaxHash.data, {where: JSON.stringify({title: 'First Post'}) }, "where clause is passed as stringified data");
   ajaxHash.success({
     results: [
       { objectId: 'bad1', title: 'First Post'},


### PR DESCRIPTION
Wrap the passed in query in a `{ where: }` if not already wrapped.  For brevity.

Been using this in my own project and seems to work pretty well, thought you guys may be interested in it.
