### PR TITLE
Add tests for addition and removal from a hasMany relationship

### DIFF
--- a/lib/ember-parse-adapter/serializer.js
+++ b/lib/ember-parse-adapter/serializer.js
@@ -165,52 +165,65 @@ EmberParseAdapter.Serializer = DS.RESTSerializer.extend({
   serializeHasMany: function(record, json, relationship){
     var key = relationship.key;
     var hasMany = record.get(key);
+
+    // No objects, just return a blank array.
+    if(!hasMany || hasMany.get("length") === 0){
+      json[key] = [];
+      return;
+    }
+
     var options = relationship.options;
-    if(hasMany && hasMany.get('length') > 0){
+    var parseClassName = this.parseClassName(relationship.type.typeKey);
+    var addOperation, removeOperation;
 
-      json[key] = { "objects": [] };
-
-      if(options.relation){
-        json[key].__op = "AddRelation";
-      }
-
-      if(options.array){
-        json[key].__op = "AddUnique";
-      }
-
+    if (hasMany && hasMany.get("length")) {
+      addOperation = {
+        __op: (options.array ? "AddUnique" : "AddRelation"),
+        objects: []
+      };
       hasMany.forEach(function(child){
-        json[key].objects.push({
+        addOperation.objects.push({
           "__type": "Pointer",
-          "className": child.parseClassName(),
-          "objectId": child.get('id')
+          "className": parseClassName,
+          "objectId": child.get("id")
         });
       });
+    }
 
-      if(hasMany._deletedItems && hasMany._deletedItems.length){
-        if(options.relation){
-          var addOperation = json[key];
-          var deleteOperation = { "__op": "RemoveRelation", "objects": [] };
-          hasMany._deletedItems.forEach(function(item){
-            deleteOperation.objects.push({
-              "__type": "Pointer",
-              "className": item.type,
-              "objectId": item.id
-            });
-          });
-          json[key] = { "__op": "Batch", "ops": [addOperation, deleteOperation] };
-        }
-        if(options.array){
-          json[key].deleteds = { "__op": "Remove", "objects": [] };
-          hasMany._deletedItems.forEach(function(item){
-            json[key].deleteds.objects.push({
-              "__type": "Pointer",
-              "className": item.type,
-              "objectId": item.id
-            });
-          });
+    if(hasMany && hasMany.get("_deletedItems.length")) {
+      removeOperation = {
+        __op: (options.array ? "Remove" : "RemoveRelation"),
+        objects: []
+      };
+      hasMany._deletedItems.forEach(function(item){
+        removeOperation.objects.push({
+          "__type": "Pointer",
+          "className": parseClassName,
+          "objectId": item.get("id")
+        });
+      });
+    }
+
+    if (options.array) {
+      if (addOperation) {
+        json[key] = addOperation;
+      }
+      if (removeOperation) {
+        if (json[key]) {
+          json[key].deleteds = removeOperation;
+        } else {
+          json[key] = {deleteds: removeOperation};
         }
       }
     } else {
+      if (addOperation && removeOperation) {
+        json[key] = { "__op": "Batch", "ops": [addOperation, removeOperation] };
+      } else if (addOperation || removeOperation) {
+        json[key] = addOperation || removeOperation;
+      }
+    }
+
+    if (!json[key]) {
       json[key] = [];
     }
   }


### PR DESCRIPTION
Refactor `serializeHasMany` to be simpler and more correct. Enable a test for adding to a hasMany, add a test for removal from a hasMany.

I'm not convinced the conditionals in the `serializeHasMany` function are correct. The items iterated for the add operation seem to just be all items in the relationship. The property iterated for the deletion operation I believe is never set (hence the failing test). I think we need some other method to see changes to the relationship instead of just checking its current state during serialization.

/cc @igorT
