### PR TITLE
Updates adapter / serializer to use JavaScriptKey

### DIFF
--- a/addon/adapters/application.js
+++ b/addon/adapters/application.js
@@ -1,39 +1,140 @@
+/*
+ * Some portions extracted from:
+ * Parse JavaScript SDK — Version: 1.4.2
+ *
+ */
+
 import Ember from 'ember';
 import DS from 'ember-data';
 
+var get = Ember.get,
+    forEach = Ember.ArrayPolyfills.forEach;
+
+
 export default DS.RESTAdapter.extend({
+  host: 'https://api.parse.com',
+  namespace: '1',
+  classesPath: 'classes',
+  parseClientVersion: 'js1.4.2',
 
-  defaultSerializer: '-parse',
-
-  init: function(){
+  init() {
     this._super();
 
-    this.set( 'headers', {
-      'X-Parse-Application-Id' : Ember.get( this, 'applicationId' ),
-      'X-Parse-REST-API-Key'   : Ember.get( this, 'restApiId' )
-    });
+    this.set('installationId', this._getInstallationId());
+    this.set('sessionToken', null);
+    this.set('userId', null);
+
+    /*
+     * avoid pre-flight.
+     * Parse._ajax
+     */
+    this.set('headers', { 'Content-Type': 'text/plain' });
   },
 
-  host: 'https://api.parse.com',
+  _getInstallationId() {
+    /*
+     * Parse._getInstallationId
+     */
+    var hexOctet = function() {
+      return (
+        Math.floor((1+Math.random())*0x10000).toString(16).substring(1)
+      );
+    };
 
-  namespace: '1',
+    return (
+      hexOctet() + hexOctet() + "-" +
+      hexOctet() + "-" +
+      hexOctet() + "-" +
+      hexOctet() + "-" +
+      hexOctet() + hexOctet() + hexOctet());
+  },
 
-  classesPath: 'classes',
+  ajaxOptions(url, type, options) {
+    var hash = options || {};
+    hash.data = hash.data || {};
+    hash.url = url;
+    hash.type = type;
+    hash.dataType = 'json';
+    hash.context = this;
 
-  pathForType: function( type ) {
-    if ( 'parseUser' === type ) {
+    if ((hash.data && type !== 'GET')) {
+      hash.contentType = 'application/json; charset=utf-8';
+
+      // Parse auth stuff
+      hash.data._ClientVersion = this.get('parseClientVersion');
+      hash.data._ApplicationId = this.get('applicationId');
+      hash.data._JavaScriptKey = this.get('javascriptKey');
+      hash.data._InstallationId = this.get('installationId');
+
+      var _sessionToken = this.get('sessionToken');
+      if (_sessionToken) {
+        hash.data._SessionToken = _sessionToken;
+      }
+
+      hash.data = JSON.stringify(hash.data);
+    }
+
+    var headers = get(this, 'headers');
+    if (headers !== undefined) {
+      hash.beforeSend = function (xhr) {
+        forEach.call(Ember.keys(headers), function(key) {
+          xhr.setRequestHeader(key, headers[key]);
+        });
+      };
+    }
+
+    return hash;
+  },
+
+  ajaxError(jqXHR, responseText, errorThrown) {
+    if (jqXHR.responseJSON.error === 'invalid session token') {
+      // invalid session
+      var session = this.container.lookup('service:session');
+      session.resetSession();
+    }
+
+    return this._super(jqXHR, responseText, errorThrown);
+  },
+
+  normalizeErrorResponse: function(status, headers, payload) {
+    return [
+      {
+        status: `${status}`,
+        title: 'The backend responded with an error',
+        details: payload.error,
+        code: payload.code
+      }
+    ];
+  },
+
+  pathForType(type) {
+    if ('parse-user' === type) {
       return 'users';
-    } else if ( 'login' === type ) {
-      return 'login';
+
+    } else if ('login' === type) {
+      return type;
+
+    } else if ('logout' === type) {
+      return type;
+
+    } else if ('requestPasswordReset' === type) {
+      return type;
+
+    } else if ('functions' === type) {
+      return 'functions';
+
     } else {
-      return this.classesPath + '/' + this.parsePathForType( type );
+      return this.classesPath + '/' + this.parsePathForType(type);
     }
   },
 
   // Using TitleStyle is recommended by Parse
-  // @TODO: test
-  parsePathForType: function( type ) {
-    return Ember.String.capitalize( Ember.String.camelize( type ) );
+  parsePathForType(type) {
+    return Ember.String.capitalize(Ember.String.camelize(type));
+  },
+
+  parseClassName(key) {
+    return Ember.String.capitalize(key);
   },
 
   /**
@@ -42,111 +143,89 @@ export default DS.RESTAdapter.extend({
   * properties onto existing data so that the record maintains
   * latest data.
   */
-  createRecord: function( store, type, record ) {
-    var serializer = store.serializerFor( type.typeKey ),
-      snapshot   = record._createSnapshot(),
-      data       = {},
-      adapter    = this;
+  createRecord(store, type, record) {
+    var serializer = store.serializerFor(type.modelName),
+      data = { _method: 'POST' },
+      adapter = this;
 
-    serializer.serializeIntoHash( data, type, snapshot, { includeId: true } );
+    serializer.serializeIntoHash(data, type, record, { includeId: true });
 
-    return new Ember.RSVP.Promise( function( resolve, reject ) {
-      adapter.ajax( adapter.buildURL( type.typeKey ), 'POST', { data: data } ).then(
-        function( json ) {
-          var completed = Ember.merge( data, json );
-          resolve( completed );
-        },
-        function( reason ) {
-          reject( reason.responseJSON );
-          }
-      );
+    var promise = new Ember.RSVP.Promise(function(resolve, reject) {
+      adapter.ajax(adapter.buildURL(type.modelName), 'POST', { data: data })
+        .then(function(json) {
+          var completed = Ember.merge(data, json);
+          resolve(completed);
+        }, function(reason) {
+          var err = `Code ${reason.responseJSON.code}: ${reason.responseJSON.error}`;
+          reject(new Error(err));
+        });
     });
+
+    return promise;
   },
 
-  /**
-  * Because Parse doesn't return a full set of properties on the
-  * responses to updates, we want to perform a merge of the response
-  * properties onto existing data so that the record maintains
-  * latest data.
-  */
-  updateRecord: function(store, type, record) {
-    var serializer  = store.serializerFor( type.typeKey ),
-      snapshot    = record._createSnapshot(),
-      id          = record.get( 'id' ),
-      sendDeletes = false,
-      deleteds    = {},
-      data        = {},
-      adapter     = this;
+  updateRecord(store, type, snapshot) {
+    var data = { _method: 'PUT' },
+        id = snapshot.id,
+        serializer = store.serializerFor(type.modelName);
 
-    serializer.serializeIntoHash(data, type, snapshot, { includeId: true });
+    serializer.serializeIntoHash(data, type, snapshot);
 
-    type.eachRelationship(function( key ) {
-      if ( data[key] && data[key].deleteds ) {
-        deleteds[key] = data[key].deleteds;
-        delete data[key].deleteds;
-        sendDeletes = true;
-      }
-    });
-
-    return new Ember.RSVP.Promise( function( resolve, reject ) {
-      if ( sendDeletes ) {
-        adapter.ajax( adapter.buildURL( type.typeKey, id ), 'PUT', { data: deleteds } ).then(
-          function() {
-            adapter.ajax( adapter.buildURL( type.typeKey, id ), 'PUT', { data: data } ).then(
-              function( updates ) {
-                // This is the essential bit - merge response data onto existing data.
-                resolve( Ember.merge( data, updates ) );
-              },
-              function( reason ) {
-                reject( 'Failed to save parent in relation: ' + reason.response.JSON );
-              }
-            );
-          },
-          function( reason ) {
-            reject( reason.responseJSON );
-          }
-        );
-
-      } else {
-        adapter.ajax( adapter.buildURL( type.typeKey, id ), 'PUT', { data: data } ).then(
-          function( json ) {
-            // This is the essential bit - merge response data onto existing data.
-            resolve( Ember.merge( data, json ) );
-          },
-          function( reason ) {
-            reject( reason.responseJSON );
-          }
-        );
-      }
-    });
+    // debugger;
+    // snapshot.record._relationships.friends.members
+    // snapshot.record._relationships.friends.canonicalMembers
+    return this.ajax(this.buildURL(type.modelName, id, snapshot), 'POST', { data: data });
   },
 
-  parseClassName: function (key ) {
-    return Ember.String.capitalize( key );
+  deleteRecord(store, type, snapshot) {
+    var data = { _method: 'DELETE' },
+        id = snapshot.id;
+
+    return this.ajax(this.buildURL(type.modelName, id, snapshot), 'POST', { data: data });
+  },
+
+  findRecord(store, type, id, snapshot) {
+    var data = { _method: 'GET' };
+    return this.ajax(this.buildURL(type.modelName, id, snapshot), 'POST', { data: data });
+  },
+
+  findAll(store, type, sinceToken) {
+    var data = { _method: 'GET' };
+
+    if (sinceToken) {
+      data.since = sinceToken;
+    }
+
+    data.where = {};
+
+    return this.ajax(this.buildURL(type.modelName), 'POST', { data: data });
   },
 
   /**
   * Implementation of a hasMany that provides a Relation query for Parse
   * objects.
   */
-  findHasMany: function( store, record, relatedInfo ) {
-    var relatedInfo_ = JSON.parse( relatedInfo ),
-        query        = {
-        where: {
-          '$relatedTo': {
-            'object': {
-              '__type'    : 'Pointer',
-              'className' : this.parseClassName( record.typeKey ),
-              'objectId'  : record.get( 'id' )
-            },
-            key: relatedInfo_.key
-          }
+  findHasMany(store, record, relationship) {
+    var related = JSON.parse(relationship);
+
+    var query = {
+      where: {
+        '$relatedTo': {
+          'object': {
+            '__type': 'Pointer',
+            'className': this.parseClassName(record.modelName),
+            'objectId': record.id
+          },
+          key: related.key
         }
+      },
+      _method: 'GET'
     };
 
     // the request is to the related type and not the type for the record.
     // the query is where there is a pointer to this record.
-    return this.ajax( this.buildURL( relatedInfo_.typeKey ), "GET", { data: query } );
+    return this.ajax(
+              this.buildURL(related.className), 'POST', { data: query });
   },
 
   /**
@@ -164,21 +243,16 @@ export default DS.RESTAdapter.extend({
   *       }
   *     });
   */
-  findQuery: function ( store, type, query ) {
-    if ( query.where && 'string' !== Ember.typeOf( query.where ) ) {
-      query.where = JSON.stringify( query.where );
-    }
-
-    // Pass to _super()
-    return this._super( store, type, query );
+  findQuery(store, type, query) {
+    query._method = 'GET';
+    return this.ajax(this.buildURL(type.modelName), 'POST', { data: query });
   },
 
-  sessionToken: Ember.computed( 'headers.X-Parse-Session-Token', function( key, value ) {
-    if ( arguments.length < 2 ) {
-      return this.get( 'headers.X-Parse-Session-Token' );
-    } else {
-      this.set( 'headers.X-Parse-Session-Token', value );
-      return value;
-    }
-  })
+  shouldReloadAll() {
+    return false;
+  },
+
+  shouldBackgroundReloadRecord() {
+    return false;
+  }
 });

--- a/addon/initializers/initialize.js
+++ b/addon/initializers/initialize.js
@@ -12,7 +12,7 @@ import ParseUser from '../models/parse-user';
 export default function( container, app ) {
   Adapter.reopen({
     applicationId : app.get( 'applicationId' ),
-    restApiId     : app.get( 'restApiId' )
+    javascriptKey : app.get( 'javascriptKey' )
   });
 
   container.register( 'adapter:-parse', Adapter );

--- a/addon/serializers/application.js
+++ b/addon/serializers/application.js
@@ -5,22 +5,22 @@ export default DS.RESTSerializer.extend({
 
   primaryKey: 'objectId',
 
-  extractArray: function( store, primaryType, payload ) {
+  extractArray(store, primaryType, payload) {
     var namespacedPayload = {};
-    namespacedPayload[ Ember.String.pluralize( primaryType.typeKey ) ] = payload.results;
+    namespacedPayload[Ember.String.pluralize(primaryType.modelName)] = payload.results;
 
-    return this._super( store, primaryType, namespacedPayload );
+    return this._super(store, primaryType, namespacedPayload);
   },
 
-  extractSingle: function( store, primaryType, payload, recordId ) {
+  extractSingle(store, primaryType, payload, recordId) {
     var namespacedPayload = {};
-    namespacedPayload[ primaryType.typeKey ] = payload; // this.normalize(primaryType, payload);
+    namespacedPayload[primaryType.modelName] = payload; // this.normalize(primaryType, payload);
 
-    return this._super( store, primaryType, namespacedPayload, recordId );
+    return this._super(store, primaryType, namespacedPayload, recordId);
   },
 
-  typeForRoot: function( key ) {
-    return Ember.String.dasherize( Ember.String.singularize( key ) );
+  typeForRoot(key) {
+    return Ember.String.dasherize(Ember.String.singularize(key));
   },
 
   /**
@@ -28,21 +28,21 @@ export default DS.RESTSerializer.extend({
   * we have to intercept it here to assure that the adapter knows which
   * record ID we are dealing with (using the primaryKey).
   */
-  extract: function( store, type, payload, id, requestType ) {
-    if( id !== null && ( 'updateRecord' === requestType || 'deleteRecord' === requestType ) ) {
-      payload[ this.get( 'primaryKey' ) ] = id;
+  extract(store, type, payload, id, requestType) {
+    if (id !== null && ('updateRecord' === requestType || 'deleteRecord' === requestType)) {
+      payload[this.get('primaryKey')] = id;
     }
 
-    return this._super( store, type, payload, id, requestType );
+    return this._super(store, type, payload, id, requestType);
   },
 
   /**
   * Extracts count from the payload so that you can get the total number
   * of records in Parse if you're using skip and limit.
   */
-  extractMeta: function( store, type, payload ) {
-    if ( payload && payload.count ) {
-      store.setMetadataFor( type, { count: payload.count } );
+  extractMeta(store, type, payload) {
+    if (payload && payload.count) {
+      store.metaForType(type, { count: payload.count });
       delete payload.count;
     }
   },
@@ -51,181 +51,206 @@ export default DS.RESTSerializer.extend({
   * Special handling for the Date objects inside the properties of
   * Parse responses.
   */
-  normalizeAttributes: function( type, hash ) {
-    type.eachAttribute( function( key, meta ) {
-      if ( 'date' === meta.type && 'object' === Ember.typeOf( hash[key] ) && hash[key].iso ) {
+  normalizeAttributes(type, hash) {
+    type.eachAttribute(function(key, meta) {
+      if ('date' === meta.type && 'object' === Ember.typeOf(hash[key]) && hash[key].iso) {
         hash[key] = hash[key].iso; //new Date(hash[key].iso).toISOString();
       }
     });
 
-    this._super( type, hash );
+    this._super(type, hash);
   },
 
-  /**
-  * Special handling of the Parse relation types. In certain
-  * conditions there is a secondary query to retrieve the "many"
-  * side of the "hasMany".
-  */
-  normalizeRelationships: function( type, hash ) {
-    var store      = this.get('store'),
-      serializer = this;
-
-    type.eachRelationship( function( key, relationship ) {
-
-      var options = relationship.options;
-
-      // Handle the belongsTo relationships
-      if ( hash[key] && 'belongsTo' === relationship.kind ) {
-        hash[key] = hash[key].objectId;
-      }
-
-      // Handle the hasMany relationships
-      if ( hash[key] && 'hasMany' === relationship.kind ) {
-
-        // If this is a Relation hasMany then we need to supply
-        // the links property so the adapter can async call the
-        // relationship.
-        // The adapter findHasMany has been overridden to make use of this.
-        if(options.relation) {
-          // hash[key] contains the response of Parse.com: eg {__type: Relation, className: MyParseClassName}
-          // this is an object that make ember-data fail, as it expects nothing or an array ids that represent the records
-          hash[key] = [];
-
-          // ember-data expects the link to be a string
-          // The adapter findHasMany will parse it
-          if (!hash.links) {
-            hash.links = {};
-          }
-
-          hash.links[key] = JSON.stringify({typeKey: relationship.type.typeKey, key: key});
+  normalizeRelationships(type, hash) {
+    if (this.keyForRelationship) {
+      type.eachRelationship(function(key, relationship) {
+        if (hash[key] && 'belongsTo' === relationship.kind) {
+          hash[key] = hash[key].objectId;
         }
 
-        if ( options.array ) {
-          // Parse will return [null] for empty relationships
-          if ( hash[key].length && hash[key] ) {
-            hash[key].forEach( function( item, index, items ) {
-              // When items are pointers we just need the id
-              // This occurs when request was made without the include query param.
-              if ( 'Pointer' === item.__type ) {
-                items[index] = item.objectId;
-
-              } else {
-                // When items are objects we need to clean them and add them to the store.
-                // This occurs when request was made with the include query param.
-                delete item.__type;
-                delete item.className;
-                item.id = item.objectId;
-                delete item.objectId;
-                item.type = relationship.type;
-                serializer.normalizeAttributes( relationship.type, item );
-                serializer.normalizeRelationships( relationship.type, item );
-                store.push( relationship.type, item );
-              }
+        /*
+         * TODO: Find a better way to do this
+         * Here we set the links property to a serialized version
+         * of key and className. This info will be passed to
+         * adapter.findHasMany where we can deserialize to create
+         * the needed Parse query.
+         */
+        if (hash[key] && 'hasMany' === relationship.kind) {
+          if (!hash[key].__op && hash[key].__op !== 'AddRelation') {
+            if (!hash.links) {
+              hash.links = {};
+            }
+            hash.links[key] = JSON.stringify({
+              key: key,
+              className: hash[key].className
             });
           }
+
+          delete hash[key].__type;
+          delete hash[key].className;
+          hash[key] = [];
         }
-      }
-    }, this );
-
-    this._super( type, hash );
+      }, this);
+    }
   },
 
-  serializeIntoHash: function( hash, type, snapshot, options ) {
-    Ember.merge( hash, this.serialize( snapshot, options ) );
-  },
-
-  serializeAttribute: function( snapshot, json, key, attribute ) {
+  serializeAttribute(record, json, key, attribute) {
     // These are Parse reserved properties and we won't send them.
-    if ( 'createdAt' === key ||
-         'updatedAt' === key ||
-         'emailVerified' === key ||
-         'sessionToken' === key
+    if ('createdAt' === key ||
+        'updatedAt' === key ||
+        'emailVerified' === key ||
+        'sessionToken' === key ||
+        'password' === key
     ) {
       delete json[key];
 
     } else {
-      this._super( snapshot, json, key, attribute );
+      this._super(record, json, key, attribute);
     }
   },
 
-  serializeBelongsTo: function( snapshot, json, relationship ) {
-    var key         = relationship.key,
-        belongsToId = snapshot.belongsTo(key, { id: true });
+  serializeBelongsTo(record, json, relationship) {
+    var key = relationship.key,
+        belongsTo = record.belongsTo(key);
 
-    if ( belongsToId ) {
+    if (belongsTo) {
+      // @TODO: Perhaps this is working around a bug in Ember-Data? Why should
+      // promises be returned here.
+      if (belongsTo instanceof DS.PromiseObject) {
+        if (!belongsTo.get('isFulfilled')) {
+          throw new Error('belongsTo values *must* be fulfilled before attempting to serialize them');
+        }
+
+        belongsTo = belongsTo.get('content');
+      }
+
+      var _className = this.parseClassName(belongsTo.type.modelName);
+
+      if (_className === 'User') {
+        _className = '_User';
+      }
+
       json[key] = {
-        '__type'    : 'Pointer',
-        'className' : this.parseClassName(key),
-        'objectId'  : belongsToId
+        '__type': 'Pointer',
+        'className': _className,
+        'objectId': belongsTo.id
       };
+
     }
   },
 
-  parseClassName: function( key ) {
-    if ( 'parseUser' === key) {
+  serializeIntoHash(hash, type, snapshot, options) {
+    var ParseACL = snapshot.record.get('ParseACL');
+
+    // Add ACL
+    if (ParseACL) {
+      var policy = {};
+
+      if (ParseACL.owner) {
+        policy[ParseACL.owner] = {};
+      }
+
+      if (ParseACL.permissions) {
+        policy[ParseACL.owner] = ParseACL.permissions;
+      } else {
+        policy[ParseACL.owner] = {
+          read: true,
+          write: true
+        };
+      }
+      hash.ACL = policy;
+    }
+
+    Ember.merge(hash, this.serialize(snapshot, options));
+  },
+
+  parseClassName(key) {
+    if ('User' === key) {
       return '_User';
 
     } else {
-      return Ember.String.capitalize( Ember.String.camelize( key ) );
+      return Ember.String.capitalize(Ember.String.camelize(key));
     }
   },
 
-  serializeHasMany: function( snapshot, json, relationship ) {
-    var key   = relationship.key,
-      hasMany = snapshot.hasMany( key ),
-      options = relationship.options,
-      _this   = this;
+  serializeHasMany(snapshot, json, relationship) {
+    var key = relationship.key;
 
-    if ( hasMany && hasMany.get( 'length' ) > 0 ) {
+    if (this._canSerialize(key)) {
+      var payloadKey;
+
       json[key] = { 'objects': [] };
 
-      if ( options.relation ) {
-        json[key].__op = 'AddRelation';
+      // if provided, use the mapping provided by `attrs` in
+      // the serializer
+      payloadKey = this._getMappedKey(key);
+      if (payloadKey === key && this.keyForRelationship) {
+        payloadKey = this.keyForRelationship(key, "hasMany");
       }
 
-      if ( options.array ) {
-        json[key].__op = 'AddUnique';
-      }
+      var relationshipType = snapshot.type.determineRelationshipType(relationship);
 
-      hasMany.forEach( function( child ) {
-        json[key].objects.push({
-          '__type'    : 'Pointer',
-          'className' : _this.parseClassName(child.type.typeKey),
-          'objectId'  : child.attr( 'id' )
+      if (relationshipType === 'manyToNone' || relationshipType === 'manyToMany' || relationshipType === 'manyToOne') {
+        var objects = [],
+            objectsForKey = snapshot.hasMany(key),
+            objectsBeforeUpdate = snapshot.record._internalModel._relationships.get(key).canonicalMembers,
+            operation = 'AddRelation';
+
+        // Check if this is removing the last relation for a key
+        if (objectsForKey.length === 0 && objectsBeforeUpdate.size === 1) {
+          // Removing the last relation
+          operation = 'RemoveRelation';
+
+          objects.push({
+            __type: 'Pointer',
+            className: this.parseClassName(snapshot.type.typeForRelationship(key).modelName),
+            objectId: objectsBeforeUpdate.list[0].id
+          });
+        }
+
+        // Determine if we are adding or removing a relationship
+        objectsForKey.forEach((item) => {
+          if (objectsForKey.length < objectsBeforeUpdate.size) {
+            // Remove existing relation
+            //
+            // Parse needs an array of the objects we want
+            // to remove so we have to invert the object list
+            // to contain items to remove
+            operation = 'RemoveRelation';
+
+            var objectsToKeepIds = objectsForKey.map(function(obj) {
+              return obj.id;
+            });
+
+            objectsBeforeUpdate.list.forEach((obj) => {
+              if (objectsToKeepIds.indexOf(obj.id) < 0) {
+                objects.push({
+                  __type: 'Pointer',
+                  className: this.parseClassName(item.modelName),
+                  objectId: obj.id
+                });
+              }
+            });
+
+          } else {
+            // Add a new relation
+            // (objectsForKey.length > objectsBeforeUpdate.size)
+            objects.push({
+              __type: 'Pointer',
+              className: this.parseClassName(item.modelName),
+              objectId: item.id
+            });
+          }
+
         });
-      });
 
-      if ( hasMany._deletedItems && hasMany._deletedItems.length ) {
-        if ( options.relation ) {
-          var addOperation    = json[key],
-            deleteOperation = { '__op': 'RemoveRelation', 'objects': [] };
-
-          hasMany._deletedItems.forEach( function( item ) {
-            deleteOperation.objects.push({
-              '__type'    : 'Pointer',
-              'className' : item.type,
-              'objectId'  : item.id
-            });
-          });
-
-          json[key] = { '__op': 'Batch', 'ops': [addOperation, deleteOperation] };
-        }
-
-        if ( options.array ) {
-          json[key].deleteds = { '__op': 'Remove', 'objects': [] };
-
-          hasMany._deletedItems.forEach( function( item ) {
-            json[key].deleteds.objects.push({
-              '__type'    : 'Pointer',
-              'className' : item.type,
-              'objectId'  : item.id
-            });
-          });
-        }
+        json[payloadKey] = {
+          __op: operation,
+          objects: objects,
+          className: this.parseClassName(snapshot.type.modelName)
+        };
+        // TODO support for polymorphic manyToNone and manyToMany relationships
       }
-
-    } else {
-      json[key] = [];
     }
   }
 

--- a/bower.json
+++ b/bower.json
@@ -1,16 +1,16 @@
 {
   "name": "ember-parse-adapter",
   "dependencies": {
-    "jquery": "^1.11.1",
-    "ember": "1.10.0",
-    "ember-data": "1.0.0-beta.15",
-    "ember-resolver": "~0.1.12",
-    "loader.js": "ember-cli/loader.js#3.2.0",
+    "ember": "1.13.2",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-load-initializers": "ember-cli/ember-load-initializers#0.0.2",
-    "ember-qunit": "0.2.8",
+    "ember-data": "1.13.2",
+    "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.4",
+    "ember-qunit": "0.3.3",
     "ember-qunit-notifications": "0.0.7",
+    "ember-resolver": "~0.1.15",
+    "jquery": "^1.11.1",
+    "loader.js": "ember-cli/loader.js#3.2.0",
     "qunit": "~1.17.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "start": "ember server",
     "build": "ember build",
-    "test": "ember test"
+    "test": "ember test",
+    "clean": "rm -rf node_modules/ bower_components/ tmp/ dist/"
   },
   "bugs": "https://github.com/clintjhill/ember-parse-adapter/issues",
   "repository": {
@@ -25,18 +26,22 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "broccoli-asset-rev": "^2.0.0",
-    "ember-cli": "0.2.0",
-    "ember-cli-app-version": "0.3.2",
-    "ember-cli-babel": "^4.0.0",
-    "ember-cli-dependency-checker": "0.0.8",
-    "ember-cli-htmlbars": "0.7.4",
+    "broccoli-asset-rev": "^2.0.2",
+    "ember-cli": "0.2.7",
+    "ember-cli-app-version": "0.3.3",
+    "ember-cli-content-security-policy": "0.4.0",
+    "ember-cli-dependency-checker": "^1.0.0",
+    "ember-cli-github-pages": "0.0.6",
+    "ember-cli-htmlbars": "0.7.6",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.3.9",
-    "ember-cli-uglify": "1.0.1",
-    "ember-data": "1.0.0-beta.15",
-    "ember-export-application-global": "^1.0.2"
+    "ember-cli-qunit": "0.3.13",
+    "ember-cli-uglify": "^1.0.1",
+    "ember-data": "1.13.2",
+    "ember-disable-prototype-extensions": "^1.0.0",
+    "ember-disable-proxy-controllers": "^1.0.0",
+    "ember-export-application-global": "^1.0.2",
+    "ember-try": "0.0.6"
   },
   "keywords": [
     "ember-addon",
@@ -46,5 +51,8 @@
   ],
   "ember-addon": {
     "configPath": "tests/dummy/config"
+  },
+  "dependencies": {
+    "ember-cli-babel": "^5.0.0"
   }
 }

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -17,7 +17,7 @@ module.exports = function(environment) {
       // Here you can pass flags/options to your application instance
       // when it is created
       applicationId: 'Hf7dgrv4WPBcJYUsLgDMZCwKxf3hdbAc1nnSsVza',
-      restApiId: 'BH0IoMxroXSVU3GTMQTVaM4BXjvdX7lKtFujgvzO'
+      javascriptKey: 'BH0IoMxroXSVU3GTMQTVaM4BXjvdX7lKtFujgvzO'
     }
   };
 

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -21,6 +21,16 @@ module.exports = function(environment) {
     }
   };
 
+  ENV.contentSecurityPolicy = {
+    'default-src': "'none'",
+    'script-src': "'self' cdnjs.cloudflare.com",
+    'font-src': "'self' cdnjs.cloudflare.com",
+    'connect-src': "'self' api.parse.com",
+    'img-src': "'self'",
+    'style-src': "'self' 'unsafe-inline' cdnjs.cloudflare.com",
+    'media-src': "'self'"
+  };
+
   if (environment === 'development') {
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;


### PR DESCRIPTION
So, this is the minimal set of changes needed to get the addon working with JavaScriptKey instead of using the REST key which is using now. This also updates the addon to ember-data 1.13.2.

As I said in the previous PR #85 this has a few deprecation warnings but everything is working. Test are failing because they need to be updated. I would love a review and some feedback on the code before fixing the tests.