### PR TITLE
camelize() in adapter's parseClassName()

### DIFF
--- a/addon/adapters/application.js
+++ b/addon/adapters/application.js
@@ -36,7 +36,7 @@ export default DS.RESTAdapter.extend({
     return Ember.String.capitalize( Ember.String.camelize( type ) );
   },
 
-  parseClassName: function (key ) {
+  parseClassName: function ( key ) {
     return Ember.String.capitalize( Ember.String.camelize( key ) );
   },
 

--- a/addon/adapters/application.js
+++ b/addon/adapters/application.js
@@ -36,6 +36,10 @@ export default DS.RESTAdapter.extend({
     return Ember.String.capitalize( Ember.String.camelize( type ) );
   },
 
+  parseClassName: function (key ) {
+    return Ember.String.capitalize( Ember.String.camelize( key ) );
+  },
+
   /**
   * Because Parse doesn't return a full set of properties on the
   * responses to updates, we want to perform a merge of the response
@@ -119,10 +123,6 @@ export default DS.RESTAdapter.extend({
         );
       }
     });
-  },
-
-  parseClassName: function (key ) {
-    return Ember.String.capitalize( key );
   },
 
   /**


### PR DESCRIPTION
parse does not support "-" in the class name. So here add camelize(). Otherwise my browser throws error when saving parse relation.

My model name looks like "one-class", and in parse it's "OneClass"
