### PR TITLE
Fixed requestPasswordReset API url

### DIFF
--- a/addon/adapters/application.js
+++ b/addon/adapters/application.js
@@ -25,6 +25,8 @@ export default DS.RESTAdapter.extend({
       return 'users';
     } else if ( 'login' === type ) {
       return 'login';
+    } else if ( 'requestPasswordReset' === type ) {
+      return 'requestPasswordReset';
     } else {
       return this.classesPath + '/' + this.parsePathForType( type );
     }


### PR DESCRIPTION
Unless I'm completely missing something, it seems that everything was implemented to utilize [Parse's request password reset](https://www.parse.com/docs/rest/guide#users-requesting-a-password-reset) endpoint except for the adapter. 

This simple change resolves that issue so that everyone can sleep at night with freshly reset passwords.
