### PR TITLE
Minor change to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,5 +115,5 @@ How to use this addon in your application
 -----------------------------------------
 
 ```
-ember install:addon ember-parse-adapter
+ember install ember-parse-adapter
 ```


### PR DESCRIPTION
The very last line of the readme instructs "install:addon" and only "install" is necessary.
